### PR TITLE
chore: upgrade nodejs to v18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
       - name: install
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
           node-version: '14.x'
       - name: install
         run: yarn --frozen-lockfile
+        env:
+          HUSKY: 0
       - name: publish
         run: npx semantic-release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,5 @@ jobs:
         run: |
           yarn --frozen-lockfile
           yarn test
+        env:
+          HUSKY: 0

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn test

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,0 @@
-{
-  "hooks": {
-    "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "flyhighair <flyhighup.air25@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "test": "renovate-config-validator"
+    "test": "renovate-config-validator",
+    "prepare": "husky install"
   },
   "renovate-config": {
     "default": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "flyhighair <flyhighup.air25@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "test": "renovate-config-validator",
+    "test": "yarn renovate-config-validator",
     "prepare": "husky install"
   },
   "renovate-config": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "@commitlint/config-conventional": "17.4.4",
     "husky": "8.0.3",
     "renovate": "34.160.0"
+  },
+  "volta": {
+    "node": "18.15.0"
   }
 }


### PR DESCRIPTION
- husky v8 対応
- node versionをv18に更新
- ローカル環境のnode versionを固定
- インストールしたrenovate-config-validatorを使用するよう修正
